### PR TITLE
npm dependencies installation added to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,8 @@ Requires python>=3.5
 .. code-block:: console
 
     $ pip install pynodered
+    # Install node dependencies
+    $ npm install follow-redirects
 
 Examples
 ------------

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Requires python>=3.5
 
     $ pip install pynodered
     # Install node dependencies
-    $ npm install follow-redirects
+    $ npm install follow-redirects url querystring
 
 Examples
 ------------


### PR DESCRIPTION
Without those npm packages the Node-RED instance won't be able to include the generated scripts.

Ideally, the installation of the npm packages should be part of the `setup.py` procedure, but that would require the assumption that the `npm` executable is installed on the target machine.