### PR TITLE
Fixed setup.py read() error for Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding = 'UTF-8') as readme_file:
     readme = readme_file.read()
 
 # commented to avoid a problem with tox testing. Need a proper fix.


### PR DESCRIPTION
While installing pynodered in a Node-Red Docker-Container the Readme.rst file was decoded as ASCII file which lead to an error thus being not able to install the pynodered package via pip:
```
# pip3 install pynodered
Collecting pynodered
  Using cached https://files.pythonhosted.org/packages/b8/0e/e7dc632620cca30311f203c957660fcc504d28583d68628b7d1c9edc20aa/pynodered-0.2.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-p48f_8gi/pynodered/setup.py", line 9, in <module>
        readme = readme_file.read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 3373: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-p48f_8gi/pynodered/
```